### PR TITLE
исправлен путь до директории проекта

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/src"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot couldn't find a package.json
Dependabot requires a package.json to evaluate your JavaScript dependencies. It had expected to find one at the path: /src/package.json

**Чек-лист**

- [x] [Кодекс поведения](./CODE_OF_CONDUCT.md) прочтен
- [x] [Руководство по содействию](./CONTRIBUTING.md) прочтен
- [ ] `Документация` добавлена / обновлена
- [ ] `Тесты` добавлены / обновлены

**Какое `изменение` содержит `Запрос на вытягивание`?**

- [ ] **Фича**
- [x] **Баг-фикс**
- [ ] **Стили** (форматирование)
- [ ] **Рефакторинг** (никаких функциональных и api изменений)
- [ ] **Производительность**
- [ ] **Документация**
- [ ] **Другое...**

**Какую `проблему` решает `Запрос на вытягивание`?**

> Просьба указать номер **Issue**

Отсутствует

**Опишите концепт решения**

Кривая настройка бота для скана зависимостей

**Иная полезная информация**

Отсутствует
